### PR TITLE
Fixed typos  names: useAverageBlockTime, useAverageFees, loadingAvеra…

### DIFF
--- a/services/explorer-ui/src/hooks/stats.ts
+++ b/services/explorer-ui/src/hooks/stats.ts
@@ -22,16 +22,16 @@ export const useTotalContracts = (): UseQueryResult<string, Error> => {
   });
 };
 
-export const useAvarageFees = (): UseQueryResult<string, Error> => {
+export const useAvеrageFees = (): UseQueryResult<string, Error> => {
   return useQuery<string, Error>({
-    queryKey: ["useAvarageFees"],
+    queryKey: ["useAvеrageFees"],
     queryFn: statsL2Api.getL2AverageFees,
   });
 };
 
-export const useAvarageBlockTime = (): UseQueryResult<string, Error> => {
+export const useAvеrageBlockTime = (): UseQueryResult<string, Error> => {
   return useQuery<string, Error>({
-    queryKey: ["useAvarageBlockTime"],
+    queryKey: ["useAvеrageBlockTime"],
     queryFn: statsL2Api.getL2AverageBlockTime,
   });
 };

--- a/services/explorer-ui/src/pages/landing/index.tsx
+++ b/services/explorer-ui/src/pages/landing/index.tsx
@@ -3,8 +3,8 @@ import { BlocksTable } from '~/components/blocks/blocks-table';
 import { TxEffectsTable } from '~/components/tx-effects/tx-effects-table';
 import { useLatestBlocks } from '~/hooks';
 import {
-  useAvarageBlockTime,
-  useAvarageFees,
+  useAvеrageBlockTime,
+  useAvеrageFees,
   useTotalContracts,
   useTotalTxEffects,
   useTotalTxEffectsLast24h,
@@ -24,20 +24,20 @@ export const Landing: FC = () => {
     error: errorTotalEffects24h,
   } = useTotalTxEffectsLast24h();
   const {
-    data: avarageFees,
-    isLoading: loadingAvarageFees,
-    error: errorAvarageFees,
-  } = useAvarageFees();
+    data: avеrageFees,
+    isLoading: loadingAvеrageFees,
+    error: errorAvеrageFees,
+  } = useAvеrageFees();
   const {
     data: totalAmountOfContracts,
     isLoading: loadingAmountContracts,
     error: errorAmountContracts,
   } = useTotalContracts();
   const {
-    data: avarageBlockTime,
-    isLoading: loadingAvarageBlockTime,
-    error: errorAvarageBlockTime,
-  } = useAvarageBlockTime();
+    data: avеrageBlockTime,
+    isLoading: loadingAvеrageBlockTime,
+    error: errorAvеrageBlockTime,
+  } = useAvеrageBlockTime();
 
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p className="text-red-500">{error.message}</p>;
@@ -82,14 +82,14 @@ export const Landing: FC = () => {
         </div>
         <div className="bg-white w-3/12 rounded-lg shadow-md p-4">
           <p>Average fee's</p>
-          {getStatsData(loadingAvarageFees, errorAvarageFees, avarageFees)}
+          {getStatsData(loadingAvеrageFees, errorAvеrageFees, avеrageFees)}
         </div>
         <div className="bg-white w-3/12 rounded-lg shadow-md p-4">
           <p>Average block time</p>
           {getStatsData(
-            loadingAvarageBlockTime,
-            errorAvarageBlockTime,
-            avarageBlockTime,
+            loadingAvеrageBlockTime,
+            errorAvеrageBlockTime,
+            avеrageBlockTime,
           )}
           ms
         </div>


### PR DESCRIPTION
Fixed typos in function and variable names to improve code readability and prevent potential issues in future development.
